### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,8 +6,8 @@
 # Library (KEYWORD1)
 #######################################
 
-WiFi		KEYWORD1	WiFi
-WiFiUdp		KEYWORD1	WiFiUDPConstructor
+WiFi	KEYWORD1	WiFi
+WiFiUdp	KEYWORD1	WiFiUDPConstructor
 WiFiClient	KEYWORD1	WiFiClientConstructor
 WiFiServer	KEYWORD1	WiFiServerConstructor
 
@@ -16,29 +16,29 @@ WiFiServer	KEYWORD1	WiFiServerConstructor
 #######################################
 
 firmwareVersion	KEYWORD2
-status		KEYWORD2
-connect		KEYWORD2
-write		KEYWORD2
+status	KEYWORD2
+connect	KEYWORD2
+write	KEYWORD2
 available	KEYWORD2
-config		KEYWORD2
-setDNS		KEYWORD2
-read		KEYWORD2
-flush		KEYWORD2
-stop		KEYWORD2
+config	KEYWORD2
+setDNS	KEYWORD2
+read	KEYWORD2
+flush	KEYWORD2
+stop	KEYWORD2
 connected	KEYWORD2
-begin		KEYWORD2
+begin	KEYWORD2
 disconnect	KEYWORD2
 macAddress	KEYWORD2
-localIP		KEYWORD2
+localIP	KEYWORD2
 subnetMask	KEYWORD2
 gatewayIP	KEYWORD2
-SSID		KEYWORD2
-BSSID		KEYWORD2
-RSSI		KEYWORD2
+SSID	KEYWORD2
+BSSID	KEYWORD2
+RSSI	KEYWORD2
 encryptionType	KEYWORD2
 WiFiClient	KEYWORD2	WiFiClient
 WiFiServer	KEYWORD2	WiFiServer
-WiFiUDP		KEYWORD2	WiFiUDPConstructor
+WiFiUDP	KEYWORD2	WiFiUDPConstructor
 beginPacket	KEYWORD2
 endPacket	KEYWORD2
 parsePacket	KEYWORD2


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords